### PR TITLE
add babel-plugin-transform-dead-code-elimination

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
 	"plugins": [
 		"transform-decorators-legacy",
 		"transform-es2015-modules-commonjs",
+		"transform-dead-code-elimination",
 		"transform-node-env-inline",
 		"lodash"
 	]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-media-keys",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Use global keyboard shortcuts to control Soundcloud, Google Play Music, and YouTube.",
   "private": true,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-eslint": "^4.1.8",
     "babel-loader": "^6.2.4",
     "babel-plugin-lodash": "2.1.0",
+    "babel-plugin-transform-dead-code-elimination": "0.0.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.6.4",
     "babel-plugin-transform-node-env-inline": "^6.5.0",


### PR DESCRIPTION
Synergizes with transform-node-env-inline: `process.env.NODE_ENV === 'development' ? a : b` -> `true ? a : b` -> `a`.